### PR TITLE
Add "intent" data attribute to the `Alert` component

### DIFF
--- a/commonjs/alert/src/Alert.js
+++ b/commonjs/alert/src/Alert.js
@@ -58,7 +58,7 @@ const Alert = (0, react_1.memo)((0, react_1.forwardRef)(function Alert(props, re
     const { appearance = 'default', children, className, hasIcon = true, intent = 'info', isRemoveable = false, onRemove, title } = props, restProps = __rest(props, ["appearance", "children", "className", "hasIcon", "intent", "isRemoveable", "onRemove", "title"]);
     const intentToken = intent === 'none' ? 'info' : intent;
     const themedProps = (0, hooks_1.useStyleConfig)('Alert', { appearance, intent: intentToken }, pseudoSelectors, internalStyles);
-    return (react_1.default.createElement(layers_1.Pane, Object.assign({ ref: ref, className: className, role: "alert" }, themedProps, restProps),
+    return (react_1.default.createElement(layers_1.Pane, Object.assign({ ref: ref, className: className, role: "alert" }, themedProps, restProps, { "data-intent": intent }),
         hasIcon && (react_1.default.createElement(layers_1.Pane, { marginRight: 16, marginLeft: 2, marginTop: -1, display: "flex", alignItems: "flex-start" }, (0, getIconForIntent_1.getIconForIntent)(intentToken, { size: 16 }))),
         react_1.default.createElement(layers_1.Pane, { flex: 1 },
             title && (react_1.default.createElement(typography_1.Heading, { is: "h4", size: 400, marginTop: 0, marginBottom: 0, fontWeight: 500, lineHeight: 1, 

--- a/esm/alert/src/Alert.js
+++ b/esm/alert/src/Alert.js
@@ -48,7 +48,9 @@ var Alert = /*#__PURE__*/memo( /*#__PURE__*/forwardRef(function Alert(props, ref
     ref: ref,
     className: className,
     role: "alert"
-  }, themedProps, restProps), hasIcon && /*#__PURE__*/React.createElement(Pane, {
+  }, themedProps, restProps, {
+    "data-intent": intent
+  }), hasIcon && /*#__PURE__*/React.createElement(Pane, {
     marginRight: 16,
     marginLeft: 2,
     marginTop: -1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evergreen-ui",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "description": "🌲 React UI Kit by Segment 🌲",
   "contributors": [
     "Jeroen Ransijn (https://jssr.design/)",

--- a/src/alert/__tests__/__snapshots__/Alert.test.js.snap
+++ b/src/alert/__tests__/__snapshots__/Alert.test.js.snap
@@ -4,6 +4,7 @@ exports[`<Alert /> appearance snapshot 1`] = `
 <DocumentFragment>
   <div
     class="ub-b-top_1px-solid-3366FF ub-b-rgt_1px-solid-3366FF ub-b-btm_1px-solid-3366FF ub-b-lft_1px-solid-3366FF  ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_F3F6FF ub-bblr_8px ub-bbrr_8px ub-btlr_8px ub-btrr_8px ub-color_2952CC ub-box-szg_border-box"
+    data-intent="info"
     role="alert"
   >
     <div
@@ -40,6 +41,7 @@ exports[`<Alert /> basic snapshot 1`] = `
 <DocumentFragment>
   <div
     class="ub-b-top_1px-solid-3366FF ub-b-rgt_1px-solid-3366FF ub-b-btm_1px-solid-3366FF ub-b-lft_1px-solid-3366FF  ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_F3F6FF ub-bblr_8px ub-bbrr_8px ub-btlr_8px ub-btrr_8px ub-color_2952CC ub-box-szg_border-box"
+    data-intent="info"
     role="alert"
   >
     <div
@@ -76,6 +78,7 @@ exports[`<Alert /> intent snapshot 1`] = `
 <DocumentFragment>
   <div
     class="ub-b-top_1px-solid-D14343 ub-b-rgt_1px-solid-D14343 ub-b-btm_1px-solid-D14343 ub-b-lft_1px-solid-D14343  ub-pst_relative ub-ovflw-x_hidden ub-ovflw-y_hidden ub-dspl_flex ub-pb_15px ub-pl_15px ub-pr_15px ub-pt_15px ub-bg-clr_FDF4F4 ub-bblr_8px ub-bbrr_8px ub-btlr_8px ub-btrr_8px ub-color_A73636 ub-box-szg_border-box"
+    data-intent="danger"
     role="alert"
   >
     <div

--- a/src/alert/src/Alert.js
+++ b/src/alert/src/Alert.js
@@ -36,7 +36,7 @@ const Alert = memo(
     const themedProps = useStyleConfig('Alert', { appearance, intent: intentToken }, pseudoSelectors, internalStyles)
 
     return (
-      <Pane ref={ref} className={className} role="alert" {...themedProps} {...restProps}>
+      <Pane ref={ref} className={className} role="alert" {...themedProps} {...restProps} data-intent={intent}>
         {hasIcon && (
           <Pane marginRight={16} marginLeft={2} marginTop={-1} display="flex" alignItems="flex-start">
             {getIconForIntent(intentToken, { size: 16 })}


### PR DESCRIPTION
**Overview**
Add `data-intent` attribute to the `Alert` component so we can:
- track Alerts by type (in Fullstory) via the `role="alert" + data-intent="xyz"` selector
- select alerts by type in E2E tests (so we don't have to check exact "toaster" text match - ref https://github.com/adtribute/analytics/pull/15816#discussion_r1850259597)

**Screenshots (if applicable)**

https://github.com/user-attachments/assets/0b960a9a-7c54-4fbc-a2c7-47c6ff448ec9



**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
