### PR TITLE
Fix disabled option display

### DIFF
--- a/commonjs/select-menu/src/Option.js
+++ b/commonjs/select-menu/src/Option.js
@@ -59,12 +59,13 @@ const internalStyles = {
     display: 'flex'
 };
 const emptyObject = {};
+const disabledTextProps = { opacity: 0.5 };
 const Option = (0, react_1.memo)((0, react_1.forwardRef)(function Option(props, ref) {
     const { children, disabled, height, isHighlighted, isSelectable, isSelected, item, onDeselect, onSelect, style: styleProp } = props, rest = __rest(props, ["children", "disabled", "height", "isHighlighted", "isSelectable", "isSelected", "item", "onDeselect", "onSelect", "style"]);
     const _a = (0, hooks_1.useStyleConfig)('Option', emptyObject, exports.pseudoSelectors, internalStyles), { style: themedStyle } = _a, themedProps = __rest(_a, ["style"]);
     const style = (0, lodash_merge_1.default)({}, styleProp, themedStyle);
     return (react_1.default.createElement(TableRow_1.default, Object.assign({ isSelectable: isSelectable && !disabled, isHighlighted: isHighlighted, onSelect: onSelect, onDeselect: onDeselect, isSelected: isSelected, style: style }, themedProps, rest, { ref: ref }),
-        react_1.default.createElement(TextTableCell_1.default, { borderRight: null, flex: 1, alignSelf: "stretch", height: height, cursor: disabled ? 'default' : 'pointer' },
+        react_1.default.createElement(TextTableCell_1.default, { borderRight: null, flex: 1, alignSelf: "stretch", height: height, cursor: disabled ? 'not-allowed' : 'pointer', textProps: disabled ? disabledTextProps : emptyObject },
             react_1.default.createElement(layers_1.Pane, { alignItems: "center", display: "flex" }, children))));
 }));
 Option.propTypes = {

--- a/esm/select-menu/src/Option.js
+++ b/esm/select-menu/src/Option.js
@@ -23,6 +23,9 @@ var internalStyles = {
   display: 'flex'
 };
 var emptyObject = {};
+var disabledTextProps = {
+  opacity: 0.5
+};
 var Option = /*#__PURE__*/memo( /*#__PURE__*/forwardRef(function Option(props, ref) {
   var children = props.children,
       disabled = props.disabled,
@@ -55,7 +58,8 @@ var Option = /*#__PURE__*/memo( /*#__PURE__*/forwardRef(function Option(props, r
     flex: 1,
     alignSelf: "stretch",
     height: height,
-    cursor: disabled ? 'default' : 'pointer'
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    textProps: disabled ? disabledTextProps : emptyObject
   }, /*#__PURE__*/React.createElement(Pane, {
     alignItems: "center",
     display: "flex"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evergreen-ui",
-  "version": "7.3.1",
+  "version": "7.3.2",
   "description": "🌲 React UI Kit by Segment 🌲",
   "contributors": [
     "Jeroen Ransijn (https://jssr.design/)",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "arrowParens": "avoid"
   },
   "lint-staged": {
-    "!(codemods|docs)/**/.{js,ts,tsx}": [
+    "!(codemods|docs)/**/*.{js,ts,tsx}": [
       "yarn lint --fix",
       "prettier --write"
     ],

--- a/src/select-menu/src/Option.js
+++ b/src/select-menu/src/Option.js
@@ -22,6 +22,7 @@ const internalStyles = {
 }
 
 const emptyObject = {}
+const disabledTextProps = { opacity: 0.5 }
 
 const Option = memo(
   forwardRef(function Option(props, ref) {
@@ -65,7 +66,8 @@ const Option = memo(
           flex={1}
           alignSelf="stretch"
           height={height}
-          cursor={disabled ? 'default' : 'pointer'}
+          cursor={disabled ? 'not-allowed' : 'pointer'}
+          textProps={disabled ? disabledTextProps : emptyObject}
         >
           <Pane alignItems="center" display="flex">
             {children}

--- a/src/select-menu/stories/index.stories.js
+++ b/src/select-menu/stories/index.stories.js
@@ -10,7 +10,7 @@ import { Pane } from '../../layers'
 import { TextInput } from '../../text-input'
 import { Text } from '../../typography'
 import Manager from './Manager'
-import options, { optionsWithIcons } from './starwars-options'
+import options, { disabledOptions, optionsWithIcons } from './starwars-options'
 
 storiesOf('select-menu', module).add('SelectMenu', () => (
   <Box padding={40}>
@@ -43,6 +43,20 @@ storiesOf('select-menu', module).add('SelectMenu', () => (
             closeOnSelect
           >
             <Button>Menu will close on select</Button>
+          </SelectMenu>
+        )}
+      </Manager>
+    </Box>
+    <Box marginBottom={24}>
+      <Manager>
+        {({ setState, state }) => (
+          <SelectMenu
+            title="Select name"
+            options={disabledOptions}
+            selected={state.selected}
+            onSelect={item => setState({ selected: item.value })}
+          >
+            <Button>Disabled options</Button>
           </SelectMenu>
         )}
       </Manager>

--- a/src/select-menu/stories/starwars-options.js
+++ b/src/select-menu/stories/starwars-options.js
@@ -10,3 +10,9 @@ export const optionsWithIcons = starWarsNames.all.map(name => ({
   value: name,
   icon: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Bananas_white_background_DS.jpg/2560px-Bananas_white_background_DS.jpg'
 }))
+
+export const disabledOptions = starWarsNames.all.map(name => ({
+  label: name,
+  value: name,
+  disabled: true
+}))


### PR DESCRIPTION
**Overview**
According to Evergreen's documentation, `disabled` options in a `SelectMenu` are supposed to be faded, but they aren't.

Ref [docs](https://evergreen.segment.com/components/select-menu#disabled_options):

<img width="961" alt="image" src="https://github.com/user-attachments/assets/0c01f67f-b89a-4544-aa24-1339a49e35f0" />




**Screenshots (if applicable)**
## Prev

<img width="1353" alt="image" src="https://github.com/user-attachments/assets/bc23c087-d9d7-40fd-8242-c7708fe179cd" />

## New
<img width="1349" alt="image" src="https://github.com/user-attachments/assets/4f6403a6-080f-400a-8224-7b3168d9dbd3" />


**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
