### PR TITLE
Bump `ui-box` to v5.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evergreen-ui",
-  "version": "7.4.0",
+  "version": "7.4.1",
   "description": "🌲 React UI Kit by Segment 🌲",
   "contributors": [
     "Jeroen Ransijn (https://jssr.design/)",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.2.0",
     "react-transition-group": "^4.4.1",
-    "ui-box": "git+https://github.com/adtribute/mqa-ui-box.git"
+    "ui-box": "github:adtribute/mqa-ui-box#v5.5.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14549,9 +14549,9 @@ typescript@4.9.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
-"ui-box@git+https://github.com/adtribute/mqa-ui-box.git":
-  version "5.4.1"
-  resolved "git+https://github.com/adtribute/mqa-ui-box.git#4da420bf8197785983ff855d6c12835302fb437d"
+"ui-box@github:adtribute/mqa-ui-box#v5.5.0":
+  version "5.5.0"
+  resolved "https://codeload.github.com/adtribute/mqa-ui-box/tar.gz/6b7fd1ea2f733cf52d53ac33e475ef628b24352f"
   dependencies:
     "@emotion/hash" "^0.7.1"
     inline-style-prefixer "^5.0.4"


### PR DESCRIPTION
**Overview**
Just realized I didn't release a new tag in [mqa-ui-box](https://github.com/adtribute/mqa-ui-box) when i did my first upgrade in https://github.com/adtribute/mqa-evergreen/pull/22. Not sure if it's the culprit of the [unit test errors in app](https://app.circleci.com/pipelines/github/adtribute/analytics/68788/workflows/b75d430f-03af-41aa-b5d6-85025383a31a/jobs/578996) but will see if this fixes that.

**Documentation**
- [ ] Updated Typescript types and/or component PropTypes
- [ ] Added / modified component docs
- [ ] Added / modified Storybook stories
