### PR TITLE
Fix annoying "webkit font smoothing" console error & add built-in tooltips to options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: ${{ matrix.node_version }}
       - id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ensure you have the following dependencies installed:
 Switch to the correct Node.js version (Node.js 16):
 
 ```bash
-nvm use 16
+nvm use
 ```
 
 To install the project dependencies, run:

--- a/commonjs/select-menu/src/OptionsList.js
+++ b/commonjs/select-menu/src/OptionsList.js
@@ -60,7 +60,7 @@ const fuzzyFilter = (options, input, { key }) => {
 };
 const noop = () => { };
 const defaultRenderItem = props => {
-    return (react_1.default.createElement(Option_1.default, Object.assign({}, props),
+    return (react_1.default.createElement(Option_1.default, Object.assign({ title: props.label }, props),
         props.icon && react_1.default.createElement(image_1.Image, { src: props.icon, width: 24, marginRight: 8 }),
         props.label));
 };

--- a/commonjs/table/src/SearchTableHeaderCell.js
+++ b/commonjs/table/src/SearchTableHeaderCell.js
@@ -44,20 +44,12 @@ const IconWrapper_1 = require("../../icons/src/IconWrapper");
 const typography_1 = require("../../typography");
 const TableHeaderCell_1 = __importDefault(require("./TableHeaderCell"));
 const noop = () => { };
-/**
- * This prop is non-standard, macOS specific and unsupported by ui-box. We probably don't need it,
- * but retaining it for backwards compatibility
- * @see https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth
- */
-const style = {
-    '-webkit-font-smoothing': 'antialiased'
-};
 const SearchTableHeaderCell = (0, react_1.memo)((0, react_1.forwardRef)(function SearchTableHeaderCell(props, ref) {
     const { value, children, onChange = noop, autoFocus, spellCheck = true, placeholder = 'Filter...', icon = icons_1.SearchIcon } = props, rest = __rest(props, ["value", "children", "onChange", "autoFocus", "spellCheck", "placeholder", "icon"]);
     const handleChange = (0, react_1.useCallback)(e => onChange(e.target.value), [onChange]);
     return (react_1.default.createElement(TableHeaderCell_1.default, Object.assign({}, rest),
         react_1.default.createElement(IconWrapper_1.IconWrapper, { icon: icon, color: "muted", marginLeft: 2, marginRight: 10, size: 12 }),
-        react_1.default.createElement(typography_1.Text, { is: "input", size: 300, flex: "1", border: "none", backgroundColor: "transparent", appearance: "none", style: style, selectors: {
+        react_1.default.createElement(typography_1.Text, { is: "input", size: 300, flex: "1", border: "none", backgroundColor: "transparent", appearance: "none", selectors: {
                 '&:focus': {
                     outline: 'none'
                 },

--- a/esm/select-menu/src/OptionsList.js
+++ b/esm/select-menu/src/OptionsList.js
@@ -1,6 +1,6 @@
-import _extends from "@babel/runtime/helpers/esm/extends";
 import _slicedToArray from "@babel/runtime/helpers/esm/slicedToArray";
 import _objectWithoutProperties from "@babel/runtime/helpers/esm/objectWithoutProperties";
+import _extends from "@babel/runtime/helpers/esm/extends";
 var _excluded = ["options", "optionSize", "close", "closeOnSelect", "onSelect", "onDeselect", "onFilterChange", "hasFilter", "selected", "optionsFilter", "isMultiSelect", "height", "width", "renderItem", "filterPlaceholder", "filterIcon", "defaultSearchValue", "shouldAutoFocus"];
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import VirtualList from '@segment/react-tiny-virtual-list';
@@ -31,7 +31,9 @@ var fuzzyFilter = function fuzzyFilter(options, input, _ref) {
 var noop = function noop() {};
 
 var defaultRenderItem = function defaultRenderItem(props) {
-  return /*#__PURE__*/React.createElement(Option, props, props.icon && /*#__PURE__*/React.createElement(Image, {
+  return /*#__PURE__*/React.createElement(Option, _extends({
+    title: props.label
+  }, props), props.icon && /*#__PURE__*/React.createElement(Image, {
     src: props.icon,
     width: 24,
     marginRight: 8

--- a/esm/table/src/SearchTableHeaderCell.js
+++ b/esm/table/src/SearchTableHeaderCell.js
@@ -14,16 +14,7 @@ import { Text } from '../../typography';
 import TableHeaderCell from './TableHeaderCell';
 
 var noop = function noop() {};
-/**
- * This prop is non-standard, macOS specific and unsupported by ui-box. We probably don't need it,
- * but retaining it for backwards compatibility
- * @see https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth
- */
 
-
-var style = {
-  '-webkit-font-smoothing': 'antialiased'
-};
 var SearchTableHeaderCell = /*#__PURE__*/memo( /*#__PURE__*/forwardRef(function SearchTableHeaderCell(props, ref) {
   var value = props.value,
       children = props.children,
@@ -54,7 +45,6 @@ var SearchTableHeaderCell = /*#__PURE__*/memo( /*#__PURE__*/forwardRef(function 
     border: "none",
     backgroundColor: "transparent",
     appearance: "none",
-    style: style,
     selectors: {
       '&:focus': {
         outline: 'none'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evergreen-ui",
-  "version": "7.4.3",
+  "version": "7.4.4",
   "description": "🌲 React UI Kit by Segment 🌲",
   "contributors": [
     "Jeroen Ransijn (https://jssr.design/)",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "arrowParens": "avoid"
   },
   "lint-staged": {
-    "!(codemods|docs)/**/*.{js,ts,tsx}": [
+    "!(codemods|docs|esm|commonjs)/**/*.{js,ts,tsx}": [
       "yarn lint --fix",
       "prettier --write"
     ],

--- a/src/select-menu/src/OptionsList.js
+++ b/src/select-menu/src/OptionsList.js
@@ -25,7 +25,7 @@ const noop = () => {}
 
 const defaultRenderItem = props => {
   return (
-    <Option {...props}>
+    <Option title={props.label} {...props}>
       {props.icon && <Image src={props.icon} width={24} marginRight={8} />}
       {props.label}
     </Option>

--- a/src/table/src/SearchTableHeaderCell.js
+++ b/src/table/src/SearchTableHeaderCell.js
@@ -7,15 +7,6 @@ import TableHeaderCell from './TableHeaderCell'
 
 const noop = () => {}
 
-/**
- * This prop is non-standard, macOS specific and unsupported by ui-box. We probably don't need it,
- * but retaining it for backwards compatibility
- * @see https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth
- */
-const style = {
-  '-webkit-font-smoothing': 'antialiased'
-}
-
 const SearchTableHeaderCell = memo(
   forwardRef(function SearchTableHeaderCell(props, ref) {
     const {
@@ -41,7 +32,6 @@ const SearchTableHeaderCell = memo(
           border="none"
           backgroundColor="transparent"
           appearance="none"
-          style={style}
           selectors={{
             '&:focus': {
               outline: 'none'


### PR DESCRIPTION
**Overview**
- `Use nvm version from .nvmrc` - a484128
- `Add built-in tooltips to OptionsList via html 'title' attr` - 8341104
  - inspired by https://github.com/adtribute/analytics/pull/17200 - seems reasonable that we should have default "tooltip"-ish elements when users cannot see the full content of an option's label
- `Remove -webkit-font-smoothing to fix Unsupported style property warning` - 3510732
- `Build` - d24cb3c
- `7.4.4` - db6b263
- `Update @actions/cache to fix CI failure` - 2bc0037

**Screenshots (if applicable)**
New built-in option tooltips:

https://github.com/user-attachments/assets/f8f1802b-0244-47e3-a175-3b0cda7175f9


