### PR TITLE
Fix click-outside detection for nested popovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ensure you have the following dependencies installed:
 - yarn (https://yarnpkg.com/)
 - NVM (Node Version Manager) (https://github.com/nvm-sh/nvm)
 
-Switch to the correct Node.js version (Node.js 16):
+Switch to the correct Node.js version:
 
 ```bash
 nvm use

--- a/commonjs/popover/fixtures/NestedPopoversFixture.js
+++ b/commonjs/popover/fixtures/NestedPopoversFixture.js
@@ -1,0 +1,36 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const react_1 = __importDefault(require("react"));
+const __1 = require("../");
+const buttons_1 = require("../../buttons");
+const layers_1 = require("../../layers");
+const typography_1 = require("../../typography");
+/**
+ * Fixture for testing nested popover behavior.
+ * Structure:
+ *   Parent Popover
+ *     ├── Child Popover A (StringMenu)
+ *     │     └── Grandchild Popover (SubMenu)
+ *     └── Child Popover B (NumberMenu) - sibling to A
+ */
+function NestedPopoversFixture({ onChildAClose, onChildBClose, onGrandchildClose, onParentClose } = {}) {
+    return (react_1.default.createElement(__1.Popover, { onClose: onParentClose, content: react_1.default.createElement(layers_1.Pane, { "data-testid": "parent-popover-content", padding: 16, width: 300 },
+            react_1.default.createElement(typography_1.Text, null, "Parent Popover Content"),
+            react_1.default.createElement(layers_1.Pane, { marginTop: 8, display: "flex", gap: 8 },
+                react_1.default.createElement(__1.Popover, { onClose: onChildAClose, content: react_1.default.createElement(layers_1.Pane, { "data-testid": "child-a-popover-content", padding: 16, width: 200 },
+                        react_1.default.createElement(typography_1.Text, null, "Child A Content"),
+                        react_1.default.createElement(__1.Popover, { onClose: onGrandchildClose, content: react_1.default.createElement(layers_1.Pane, { "data-testid": "grandchild-popover-content", padding: 16, width: 150 },
+                                react_1.default.createElement(typography_1.Text, null, "Grandchild Content"),
+                                react_1.default.createElement(buttons_1.Button, { "data-testid": "grandchild-action" }, "Action")) },
+                            react_1.default.createElement(buttons_1.Button, { "data-testid": "grandchild-trigger", marginTop: 8 }, "Open Grandchild"))) },
+                    react_1.default.createElement(buttons_1.Button, { "data-testid": "child-a-trigger" }, "Open Child A")),
+                react_1.default.createElement(__1.Popover, { onClose: onChildBClose, content: react_1.default.createElement(layers_1.Pane, { "data-testid": "child-b-popover-content", padding: 16, width: 200 },
+                        react_1.default.createElement(typography_1.Text, null, "Child B Content"),
+                        react_1.default.createElement(buttons_1.Button, { "data-testid": "child-b-action" }, "Action B")) },
+                    react_1.default.createElement(buttons_1.Button, { "data-testid": "child-b-trigger" }, "Open Child B")))) },
+        react_1.default.createElement(buttons_1.Button, { "data-testid": "parent-trigger" }, "Open Parent")));
+}
+exports.default = NestedPopoversFixture;

--- a/commonjs/popover/src/Popover.js
+++ b/commonjs/popover/src/Popover.js
@@ -215,7 +215,7 @@ const Popover = (0, react_1.memo)((0, react_1.forwardRef)(function Popover(_a, f
         if (shouldCloseOnExternalClick !== false) {
             close();
         }
-    }, [onBodyClick, shouldCloseOnExternalClick, close, targetRef.current, popoverNode.current, popoverId]);
+    }, [onBodyClick, shouldCloseOnExternalClick, close, popoverId]);
     const handleOpenComplete = (0, react_1.useCallback)(() => {
         if (shouldBringFocusInside)
             bringFocusInside();

--- a/esm/popover/src/Popover.js
+++ b/esm/popover/src/Popover.js
@@ -274,7 +274,7 @@ var Popover = /*#__PURE__*/memo( /*#__PURE__*/forwardRef(function Popover(_ref, 
     if (shouldCloseOnExternalClick !== false) {
       close();
     }
-  }, [onBodyClick, shouldCloseOnExternalClick, close, targetRef.current, popoverNode.current, popoverId]);
+  }, [onBodyClick, shouldCloseOnExternalClick, close, popoverId]);
   var handleOpenComplete = useCallback(function () {
     if (shouldBringFocusInside) bringFocusInside();
     onOpenComplete();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evergreen-ui",
-  "version": "7.4.4",
+  "version": "7.5.0",
   "description": "🌲 React UI Kit by Segment 🌲",
   "contributors": [
     "Jeroen Ransijn (https://jssr.design/)",

--- a/src/popover/__tests__/NestedPopovers.test.js
+++ b/src/popover/__tests__/NestedPopovers.test.js
@@ -1,0 +1,229 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import NestedPopoversFixture from '../fixtures/NestedPopoversFixture'
+
+describe('Nested Popovers', () => {
+  describe('Parent-Child relationship', () => {
+    it('should keep parent open when clicking inside child popover', async () => {
+      render(<NestedPopoversFixture />)
+
+      // Open parent
+      await userEvent.click(screen.getByTestId('parent-trigger'))
+      const parentContent = await screen.findByTestId('parent-popover-content')
+      expect(parentContent).toBeVisible()
+
+      // Open child A
+      await userEvent.click(screen.getByTestId('child-a-trigger'))
+      const childAContent = await screen.findByTestId('child-a-popover-content')
+      expect(childAContent).toBeVisible()
+
+      // Click inside child A content - parent should stay open
+      await userEvent.click(childAContent)
+
+      expect(parentContent).toBeVisible()
+      expect(childAContent).toBeVisible()
+    })
+
+    it('should close child when clicking inside parent but outside child', async () => {
+      const onChildAClose = jest.fn()
+      render(<NestedPopoversFixture onChildAClose={onChildAClose} />)
+
+      // Open parent
+      await userEvent.click(screen.getByTestId('parent-trigger'))
+      const parentContent = await screen.findByTestId('parent-popover-content')
+
+      // Open child A
+      await userEvent.click(screen.getByTestId('child-a-trigger'))
+      await screen.findByTestId('child-a-popover-content')
+
+      // Click inside parent but outside child A
+      await userEvent.click(parentContent)
+
+      // Child should close, parent should stay open
+      await waitFor(() => {
+        expect(onChildAClose).toHaveBeenCalled()
+      })
+      expect(parentContent).toBeVisible()
+    })
+
+    it('should close all nested popovers when clicking outside parent', async () => {
+      const onParentClose = jest.fn()
+      const onChildAClose = jest.fn()
+      render(<NestedPopoversFixture onParentClose={onParentClose} onChildAClose={onChildAClose} />)
+
+      // Open parent
+      await userEvent.click(screen.getByTestId('parent-trigger'))
+      await screen.findByTestId('parent-popover-content')
+
+      // Open child A
+      await userEvent.click(screen.getByTestId('child-a-trigger'))
+      await screen.findByTestId('child-a-popover-content')
+
+      // Click outside everything
+      await userEvent.click(document.body)
+
+      await waitFor(() => {
+        expect(onParentClose).toHaveBeenCalled()
+        expect(onChildAClose).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('Sibling popovers', () => {
+    it('should close sibling popover when opening another sibling', async () => {
+      const onChildAClose = jest.fn()
+      render(<NestedPopoversFixture onChildAClose={onChildAClose} />)
+
+      // Open parent
+      await userEvent.click(screen.getByTestId('parent-trigger'))
+      await screen.findByTestId('parent-popover-content')
+
+      // Open child A
+      await userEvent.click(screen.getByTestId('child-a-trigger'))
+      await screen.findByTestId('child-a-popover-content')
+
+      // Open child B (sibling) - child A should close
+      await userEvent.click(screen.getByTestId('child-b-trigger'))
+      await screen.findByTestId('child-b-popover-content')
+
+      await waitFor(() => {
+        expect(onChildAClose).toHaveBeenCalled()
+      })
+    })
+
+    it('should keep parent open when switching between sibling popovers', async () => {
+      const onParentClose = jest.fn()
+      render(<NestedPopoversFixture onParentClose={onParentClose} />)
+
+      // Open parent
+      await userEvent.click(screen.getByTestId('parent-trigger'))
+      const parentContent = await screen.findByTestId('parent-popover-content')
+
+      // Open child A
+      await userEvent.click(screen.getByTestId('child-a-trigger'))
+      await screen.findByTestId('child-a-popover-content')
+
+      // Open child B (sibling)
+      await userEvent.click(screen.getByTestId('child-b-trigger'))
+      await screen.findByTestId('child-b-popover-content')
+
+      // Parent should still be open
+      expect(parentContent).toBeVisible()
+      expect(onParentClose).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Multiple levels of nesting (grandchild)', () => {
+    it('should keep all ancestors open when clicking inside grandchild', async () => {
+      render(<NestedPopoversFixture />)
+
+      // Open parent
+      await userEvent.click(screen.getByTestId('parent-trigger'))
+      const parentContent = await screen.findByTestId('parent-popover-content')
+
+      // Open child A
+      await userEvent.click(screen.getByTestId('child-a-trigger'))
+      const childAContent = await screen.findByTestId('child-a-popover-content')
+
+      // Open grandchild
+      await userEvent.click(screen.getByTestId('grandchild-trigger'))
+      const grandchildContent = await screen.findByTestId('grandchild-popover-content')
+
+      // Click inside grandchild - all ancestors should stay open
+      await userEvent.click(screen.getByTestId('grandchild-action'))
+
+      expect(parentContent).toBeVisible()
+      expect(childAContent).toBeVisible()
+      expect(grandchildContent).toBeVisible()
+    })
+
+    it('should close grandchild when clicking inside child but outside grandchild', async () => {
+      const onGrandchildClose = jest.fn()
+      render(<NestedPopoversFixture onGrandchildClose={onGrandchildClose} />)
+
+      // Open parent -> child A -> grandchild
+      await userEvent.click(screen.getByTestId('parent-trigger'))
+      await screen.findByTestId('parent-popover-content')
+
+      await userEvent.click(screen.getByTestId('child-a-trigger'))
+      const childAContent = await screen.findByTestId('child-a-popover-content')
+
+      await userEvent.click(screen.getByTestId('grandchild-trigger'))
+      await screen.findByTestId('grandchild-popover-content')
+
+      // Click inside child A but outside grandchild
+      await userEvent.click(childAContent)
+
+      await waitFor(() => {
+        expect(onGrandchildClose).toHaveBeenCalled()
+      })
+    })
+
+    it('should close grandchild and child when clicking inside parent', async () => {
+      const onChildAClose = jest.fn()
+      const onGrandchildClose = jest.fn()
+      render(<NestedPopoversFixture onChildAClose={onChildAClose} onGrandchildClose={onGrandchildClose} />)
+
+      // Open parent -> child A -> grandchild
+      await userEvent.click(screen.getByTestId('parent-trigger'))
+      const parentContent = await screen.findByTestId('parent-popover-content')
+
+      await userEvent.click(screen.getByTestId('child-a-trigger'))
+      await screen.findByTestId('child-a-popover-content')
+
+      await userEvent.click(screen.getByTestId('grandchild-trigger'))
+      await screen.findByTestId('grandchild-popover-content')
+
+      // Click inside parent but outside child A
+      await userEvent.click(parentContent)
+
+      await waitFor(() => {
+        expect(onGrandchildClose).toHaveBeenCalled()
+        expect(onChildAClose).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should handle rapid open/close cycles', async () => {
+      render(<NestedPopoversFixture />)
+
+      // Rapidly toggle parent
+      const parentTrigger = screen.getByTestId('parent-trigger')
+      await userEvent.click(parentTrigger)
+      await userEvent.click(parentTrigger)
+      await userEvent.click(parentTrigger)
+
+      const parentContent = await screen.findByTestId('parent-popover-content')
+      expect(parentContent).toBeVisible()
+    })
+
+    it('should not interfere with unrelated popovers', async () => {
+      // Render two independent popover trees
+      render(
+        <>
+          <NestedPopoversFixture />
+          <div data-testid="separator" style={{ margin: '20px' }} />
+          <NestedPopoversFixture />
+        </>
+      )
+
+      const triggers = screen.getAllByTestId('parent-trigger')
+
+      // Open first parent
+      await userEvent.click(triggers[0])
+      const parentContents = await screen.findAllByTestId('parent-popover-content')
+      expect(parentContents[0]).toBeVisible()
+
+      // Open second parent - first should close (they're both at root level)
+      await userEvent.click(triggers[1])
+
+      await waitFor(() => {
+        const visibleParents = screen.getAllByTestId('parent-popover-content')
+        // At least the second one should be visible
+        expect(visibleParents.length).toBeGreaterThanOrEqual(1)
+      })
+    })
+  })
+})

--- a/src/popover/fixtures/NestedPopoversFixture.js
+++ b/src/popover/fixtures/NestedPopoversFixture.js
@@ -1,0 +1,70 @@
+import React from 'react'
+import { Popover } from '../'
+import { Button } from '../../buttons'
+import { Pane } from '../../layers'
+import { Text } from '../../typography'
+
+/**
+ * Fixture for testing nested popover behavior.
+ * Structure:
+ *   Parent Popover
+ *     ├── Child Popover A (StringMenu)
+ *     │     └── Grandchild Popover (SubMenu)
+ *     └── Child Popover B (NumberMenu) - sibling to A
+ */
+function NestedPopoversFixture({ onChildAClose, onChildBClose, onGrandchildClose, onParentClose } = {}) {
+  return (
+    <Popover
+      onClose={onParentClose}
+      content={
+        <Pane data-testid="parent-popover-content" padding={16} width={300}>
+          <Text>Parent Popover Content</Text>
+          <Pane marginTop={8} display="flex" gap={8}>
+            {/* Child Popover A */}
+            <Popover
+              onClose={onChildAClose}
+              content={
+                <Pane data-testid="child-a-popover-content" padding={16} width={200}>
+                  <Text>Child A Content</Text>
+                  {/* Grandchild Popover */}
+                  <Popover
+                    onClose={onGrandchildClose}
+                    content={
+                      <Pane data-testid="grandchild-popover-content" padding={16} width={150}>
+                        <Text>Grandchild Content</Text>
+                        <Button data-testid="grandchild-action">Action</Button>
+                      </Pane>
+                    }
+                  >
+                    <Button data-testid="grandchild-trigger" marginTop={8}>
+                      Open Grandchild
+                    </Button>
+                  </Popover>
+                </Pane>
+              }
+            >
+              <Button data-testid="child-a-trigger">Open Child A</Button>
+            </Popover>
+
+            {/* Child Popover B (sibling) */}
+            <Popover
+              onClose={onChildBClose}
+              content={
+                <Pane data-testid="child-b-popover-content" padding={16} width={200}>
+                  <Text>Child B Content</Text>
+                  <Button data-testid="child-b-action">Action B</Button>
+                </Pane>
+              }
+            >
+              <Button data-testid="child-b-trigger">Open Child B</Button>
+            </Popover>
+          </Pane>
+        </Pane>
+      }
+    >
+      <Button data-testid="parent-trigger">Open Parent</Button>
+    </Popover>
+  )
+}
+
+export default NestedPopoversFixture

--- a/src/popover/src/Popover.js
+++ b/src/popover/src/Popover.js
@@ -264,7 +264,7 @@ const Popover = memo(
           close()
         }
       },
-      [onBodyClick, shouldCloseOnExternalClick, close, targetRef.current, popoverNode.current, popoverId]
+      [onBodyClick, shouldCloseOnExternalClick, close, popoverId]
     )
 
     const handleOpenComplete = useCallback(() => {


### PR DESCRIPTION
## Summary

Overhaul Popover's click-outside detection to fix multiple issues with nested popovers and interactions within popover content.

### Nested popover tracking
- Add a module-level popover registry (`Map`) to track open popovers and their parent IDs
- Add `PopoverParentContext` to flow parent ID through React's component tree (which portals preserve, unlike the DOM tree)
- Modify `handleBodyClick` to ignore clicks inside descendant popovers
- Register/unregister popovers via ref callback to handle react-transition-group timing

This fixes an issue where clicking inside a child popover (e.g., a SelectMenu inside a Popover) would incorrectly trigger the parent popover's click-outside handler and close it.

### Capture phase + pointerdown target recording
- Switch event listeners from bubble phase on `document.body` to **capture phase** on `document`
- Record the click target at `pointerdown` time (before React re-renders can detach DOM nodes) and use that for `contains()` checks instead of `event.target`

This fixes two additional issues:
- **Detached DOM nodes**: Clicks inside a popover that trigger React re-renders (e.g., selecting a list item) could cause the clicked element to be removed from the DOM before the click handler fired, making `contains()` return false and incorrectly closing the popover
- **`stopPropagation` interference**: `e.stopPropagation()` calls in bubble-phase handlers (unrelated to Popover) would prevent click events from reaching `document.body`, breaking click-outside detection entirely

The capture phase + pointerdown approach matches how [Headless UI](https://github.com/tailwindlabs/headlessui) and [React Aria](https://github.com/adobe/react-spectrum) handle this problem.

## Breaking changes

Code that relied on `e.stopPropagation()` to prevent a popover from closing will no longer work. Use `shouldCloseOnExternalClick={false}` instead, which is the intended API for that behavior.

***

Was tested in `analytics` via https://github.com/adtribute/analytics/pull/19665
