### PR TITLE
chore: release 7.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evergreen-ui",
-  "version": "7.6.0",
+  "version": "7.7.0",
   "description": "🌲 React UI Kit by Segment 🌲",
   "contributors": [
     "Jeroen Ransijn (https://jssr.design/)",


### PR DESCRIPTION
## Summary
- Bump package version to 7.7.0 after merging React 19 support (#39)

## Release
- `v7.7.0` tag has already been pushed and points at this version commit